### PR TITLE
Fix crash on jumping to nauvis

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1,6 +1,14 @@
 require("control-functions") -- add_starting_fissure
 
 function on_warp(event)
+    -- Apply surface modifications to newly generated surfaces (i.e. not Nauvis and not the surface marked as a homeworld)
+    local homeworld_surface = remote.call("warptorio","GetHomeSurface")
+    if event.newsurface.name ~= "nauvis" and event.newsurface ~= homeworld_surface then
+        add_surface_modifications(event)
+    end
+end
+
+function add_surface_modifications(event)
     -- Add surface gems on resource-specific worlds
     for _,flag in pairs(event.newplanet.flags) do
         if flag == "resource-specific" then


### PR DESCRIPTION
the code expected the surface to have some flags but nauvis doesnt seem to have flags. we dont really need to process nauvis anyway and the homeworld was probably already processed.

```
1580.281 Error MainLoop.cpp:1288: Exception at tick 25956840: The mod Industrial Revolution Warptorio Compatibility (0.0.7) caused a non-recoverable error.
Please report this error to the mod author.

Error while running event ir-warptorio-compat::Custom event (ID 258)
__ir-warptorio-compat__/control.lua:5: bad argument #1 of 2 to 'pairs' (table expected, got nil)
```